### PR TITLE
Remove old stages from `dvc.lock`

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -1,29 +1,20 @@
+---
 schema: '2.0'
 stages:
-  1-stage:
-    cmd: Rscript stages/01-stage.R
-    deps:
-    - path: stages/01-stage.R
-      md5: c468dc14527e00c339f146e1dba2bd3b
-      size: 118
-    outs:
-    - path: data/mtcars.parquet
-      md5: 77cf29accf9535522fad7db1486eff9a
-      size: 6243
   build:
     cmd: Rscript stages/download.R
     deps:
-    - path: https://clowder.edap-cluster.com/spaces/62bb560ee4b07abf29f88fef
+    - checksum: '308151993323152722451194344924838091589'
       hash: md5
-      checksum: '308151993323152722451194344924838091589'
+      path: https://clowder.edap-cluster.com/spaces/62bb560ee4b07abf29f88fef
       size: 33866
-    - path: stages/download.R
-      hash: md5
+    - hash: md5
       md5: ec800973d471bab40b8abda8e60f39cc
+      path: stages/download.R
       size: 1025
     outs:
-    - path: brick/invitrodb.parquet
-      hash: md5
+    - hash: md5
       md5: 110a6e966af64a8ad0c686b7bf8c908e.dir
-      size: 718228060
       nfiles: 4
+      path: brick/invitrodb.parquet
+      size: 718228060


### PR DESCRIPTION
Many bricks have old stages from the brick-template.
